### PR TITLE
Fall back to `require('component-matches-selector')`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@
  * Module Dependencies
  */
 
-var matches = require('matches-selector')
+try {
+  var matches = require('matches-selector')
+} catch (err) {
+  var matches = require('component-matches-selector')
+}
 
 /**
  * Export `closest`


### PR DESCRIPTION
This way, `component-closest` won't break node code/tests when imported.

/cc @vendethiel 
