### PR TITLE
Bump matches-selector dependency to 0.1.6

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "repo": "component/closest",
   "dependencies": {
-    "component/matches-selector": "0.1.5"
+    "component/matches-selector": "0.1.6"
   },
   "main": "index.js",
   "scripts": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Jonathan Ong",
   "dependencies": {
-    "component-matches-selector": "~0.1.5"
+    "component-matches-selector": "~0.1.6"
   },
   "browser": {
     "matches-selector": "component-matches-selector"


### PR DESCRIPTION
(Which includes component/matches-selector#15)

Don't release yet (to npm), as `component-matches-selector` hasn't been released to it yet. (Would appreciate if someone with the necessary privileges could do that.)

/cc @vendethiel 
